### PR TITLE
Results mobile padding

### DIFF
--- a/src/components/markdownComponents.js
+++ b/src/components/markdownComponents.js
@@ -18,7 +18,7 @@ class ResultsBanner extends React.Component {
 
         return (
             <div
-                className="nl6-ns nr6-ns nl4-m nr4-m nl3 nr3 mv6 pa7-ns pv6 bg-near-white flex flex-row-l flex-column justify-around relative"
+                className="nl6-ns nr6-ns nl4-m nr4-m nl3 nr3 mv6 pa7-ns pv6 ph3 bg-near-white flex flex-row-l flex-column justify-around relative"
             >
                 {
                     Object.keys(dataObj).map((i, n) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `ph3` to `ResultsBanner` to restore horizontal padding on mobile.

The `ResultsBanner` component had negative horizontal margins (`nl3 nr3`) and `pa7-ns` (padding only for non-small screens), causing content to be flush with the left edge on mobile.

<div><a href="https://cursor.com/agents/bc-658bcbc0-8cc8-4444-ac77-019c60ea8fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-658bcbc0-8cc8-4444-ac77-019c60ea8fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->